### PR TITLE
Enable Support for commandline arg. to Java Prog.

### DIFF
--- a/ShellScripts/JavaOnTermux.sh
+++ b/ShellScripts/JavaOnTermux.sh
@@ -11,7 +11,7 @@ then
 	# Compile and Execute
 	ecj $file_name.java
 	dx --dex --output=$file_name.dex $file_name.class
-	dalvikvm -cp $file_name.dex $file_name
+	dalvikvm -cp $file_name.dex $file_name ${@:2}
 
 elif [ "$cmd_arg" == "install" ]
 then


### PR DESCRIPTION
Before this change, if we run
```bash JavaOnTermux.sh <filename> arg1 arg2 ...```
It only executes Java program without passing
commandline arguments to it.

So, now we are able to pass commandline arguments
to Java program.